### PR TITLE
Update quest target ID for Set in Stone quest

### DIFF
--- a/src/Golden Lotus Dailies/Golden_Lotus_11_Set_in_Stone.lua
+++ b/src/Golden Lotus Dailies/Golden_Lotus_11_Set_in_Stone.lua
@@ -6,7 +6,7 @@ BANETO_DefineQuestStepType([[KillAndLoot]])
 BANETO_DefineQuestId(30309)
 
 -- Quest Objective -
-BANETO_DefineQuestTargetId(58855) -- Mogu Effigies
+BANETO_DefineQuestTargetId(59156) -- Mogu Effigies
 
 -- Quest Locations
 BANETO_DefineCenter(1467.1362304688, 1356.7120361328, 445.89776611328, 300)


### PR DESCRIPTION
Changed the quest target ID from 58855 to 59156 for the Mogu Effigies in the Golden Lotus 'Set in Stone' daily quest script.